### PR TITLE
Rename project to 'crochet'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "cricket_cli"
+name = "crochet_cli"
 version = "0.1.0"
 dependencies = [
  "chumsky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cricket_cli"
+name = "crochet_cli"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,7 +7,7 @@ edition = "2021"
 strip = "debuginfo"
 
 [lib]
-name = "cricket"
+name = "crochet"
 crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# cricket 🏏
+# crochet 🧣
 
 A compile-to-JavaScript language with tight TypeScript integration.

--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -42,7 +42,7 @@ export const App = () => {
   // TODO: use CSS Grid for this
   return (
     <div style={styles.app}>
-      <h1>cricket demo</h1>
+      <h1>crochet demo</h1>
       <div style={{ width: "100%", height: "100%", display: "flex" }}>
         <textarea
           style={styles.textArea}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cricket",
+  "name": "crochet",
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use chumsky::prelude::*;
 use std::collections::HashMap;
 
-use cricket::parser::*;
-use cricket::lexer::*;
-use cricket::context::Env;
-use cricket::infer::*;
+use crochet::parser::*;
+use crochet::lexer::*;
+use crochet::context::Env;
+use crochet::infer::*;
 
 fn main() {
     println!("Hello, world!");

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -1,9 +1,9 @@
 use chumsky::prelude::*;
 
-use cricket::js::builder::build_js;
-use cricket::js::printer::print_js;
-use cricket::lexer::lexer;
-use cricket::parser::token_parser;
+use crochet::js::builder::build_js;
+use crochet::js::printer::print_js;
+use crochet::lexer::lexer;
+use crochet::parser::token_parser;
 
 fn compile(input: &str) -> String {
     let result = lexer().parse(input).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,13 +1,13 @@
 use chumsky::prelude::*;
 use std::collections::HashMap;
 
-use cricket::context::Env;
-use cricket::infer::{infer_stmt, infer_prog};
-use cricket::parser::token_parser;
-use cricket::lexer::lexer;
-use cricket::types::*;
-use cricket::ts::convert::{extend_scheme};
-use cricket::syntax::{Pattern, Program};
+use crochet::context::Env;
+use crochet::infer::{infer_stmt, infer_prog};
+use crochet::parser::token_parser;
+use crochet::lexer::lexer;
+use crochet::types::*;
+use crochet::ts::convert::{extend_scheme};
+use crochet::syntax::{Pattern, Program};
 
 fn infer(input: &str) -> String {
     let env: Env = HashMap::new();
@@ -50,7 +50,7 @@ fn build_d_ts(env: &Env, prog: &Program) -> String {
 
     for (statement, _) in &prog.body {
         match statement {
-            cricket::syntax::Statement::Decl { pattern: (pat, _), value: (expr, _) } => {
+            crochet::syntax::Statement::Decl { pattern: (pat, _), value: (expr, _) } => {
                 let name = match pat {
                     Pattern::Ident { name } => name,
                 };


### PR DESCRIPTION
`cricket` is ambiguous because it could mean the game or the insect.